### PR TITLE
Add increase max hp feature

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,2 +1,3 @@
+MaxHealthIncrease = 0 -- How much the player's max health will be increased by.
 HealAmount = 15 -- How much the player is healed.
 DropChance = 10 -- Higher values means lower chance. Set to 0 for 100% drop chance. Set to 1 for 50% drop chance. etc

--- a/files/data/scripts/items/health_container_pickup.lua
+++ b/files/data/scripts/items/health_container_pickup.lua
@@ -10,11 +10,13 @@ function item_pickup( entity_item, entity_who_picked, item_name )
 	if( damagemodels ~= nil ) then
 		for i,v in ipairs(damagemodels) do
 			currenthp = tonumber( ComponentGetValue( v, "hp" ) )
-			max_hp = tonumber( ComponentGetValue( v, "max_hp") )
+			current_max_hp = tonumber( ComponentGetValue( v, "max_hp") )
 			
 			local targethp = currenthp + (HealAmount * 0.04) -- Health values are scaled up by 25 in the UI apparently. So using this multiplier will allow the correct hp to be set
+			local target_max_hp = current_max_hp + (MaxHealthIncrease * 0.04)
 			
-			if( targethp > max_hp ) then targethp = max_hp end
+			ComponentSetValue( v, "max_hp", target_max_hp)
+			if( targethp > target_max_hp ) then targethp = target_max_hp end
 			ComponentSetValue( v, "hp", targethp)
 			break
 		end


### PR DESCRIPTION
Add a configurable value of how much the max health should be increased on health pack pickup along with being healed. Default value starts at 0 so that each player can chose to use this feature or not on their own.