### PR TITLE
Implementation of HP by percentage; Mod Settings Menu; More intuitive drop logic

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,0 @@
-MaxHealthIncrease = 0 -- How much the player's max health will be increased by.
-HealAmount = 10 -- How much the player is healed (if set to a fixed amount).
-HealPercent = 10 -- How much to heal the player by percentage of max health (if set to percent).
-DropChance = 15 -- Higher values means lower chance. Set to 0 for 100% drop chance. Set to 1 for 50% drop chance. etc
-HealMode = PERCENT -- valid values are "PERCENT" or "FIXED"

--- a/config.lua
+++ b/config.lua
@@ -1,3 +1,5 @@
 MaxHealthIncrease = 0 -- How much the player's max health will be increased by.
-HealAmount = 10 -- How much the player is healed.
+HealAmount = 10 -- How much the player is healed (if set to a fixed amount).
+HealPercent = 10 -- How much to heal the player by percentage of max health (if set to percent).
 DropChance = 15 -- Higher values means lower chance. Set to 0 for 100% drop chance. Set to 1 for 50% drop chance. etc
+HealMode = PERCENT -- valid values are "PERCENT" or "FIXED"

--- a/files/data/entities/items/pickup/health_container.xml
+++ b/files/data/entities/items/pickup/health_container.xml
@@ -1,9 +1,9 @@
-<Entity name="unknown" tags="item_physics" >
+<Entity name="health_container_entity" tags="item_physics" >
 
   <!-- physical presence -->
-	<UIInfoComponent
+	<!-- <UIInfoComponent
 		name="$item_healthcontainer">
-	</UIInfoComponent>
+	</UIInfoComponent> -->
 
   <PhysicsBodyComponent 
     _tags="enabled_in_world"

--- a/files/data/entities/particles/health_container_pickup.xml
+++ b/files/data/entities/particles/health_container_pickup.xml
@@ -1,48 +1,46 @@
 <Entity>
 
-    <VelocityComponent
-        gravity_y="0"
-        air_friction="4.0" >
-    </VelocityComponent>
+  <VelocityComponent
+      gravity_y="0"
+      air_friction="4.0" >
+  </VelocityComponent>
 
-    <SimplePhysicsComponent>
-    </SimplePhysicsComponent>
+  <SimplePhysicsComponent>
+  </SimplePhysicsComponent>
 
-    <LifetimeComponent
-		lifetime="6"
-		>
+  <LifetimeComponent
+    lifetime="6" >
 	</LifetimeComponent>
 
-    <SpriteParticleEmitterComponent
-        sprite_file="data/particles/heal.xml"
-		lifetime="5"
-		color.r="1" color.g="1" color.b="1" color.a="1"
-		color_change.r="0" color_change.g="0" color_change.b="0" color_change.a="-5"
-        emission_interval_min_frames="1"
-        emission_interval_max_frames="1"
-        additive="1"
-        emissive="0"
-        scale.x="1.0"
-        scale.y="1.0"
-		count_min="1"
-		count_max="2"
-        sprite_random_rotation="1"
-        randomize_scale.min_x="-0.1" 
-        randomize_scale.max_x="0.1" 
-        randomize_scale.min_y="-0.1" 
-        randomize_scale.max_y="0.1" 
-        randomize_velocity.min_y="-30" 
-        randomize_velocity.max_y="30"
-        randomize_velocity.min_x="-30" 	
-        randomize_velocity.max_x="30"
-		randomize_position.min_y="-2" 
-        randomize_position.max_y="2"
-        randomize_position.min_x="-2"  
-        randomize_position.max_x="2"
-        randomize_animation_speed_coeff.min="0.667"  
-        randomize_animation_speed_coeff.max="1.0" 
-		>
-    </SpriteParticleEmitterComponent>
+  <SpriteParticleEmitterComponent
+    sprite_file="data/particles/heal.xml"
+    lifetime="5"
+    color.r="1" color.g="1" color.b="1" color.a="1"
+    color_change.r="0" color_change.g="0" color_change.b="0" color_change.a="-5"
+    emission_interval_min_frames="1"
+    emission_interval_max_frames="1"
+    additive="1"
+    emissive="0"
+    scale.x="1.0"
+    scale.y="1.0"
+    count_min="1"
+    count_max="2"
+    sprite_random_rotation="1"
+    randomize_scale.min_x="-0.1" 
+    randomize_scale.max_x="0.1" 
+    randomize_scale.min_y="-0.1" 
+    randomize_scale.max_y="0.1" 
+    randomize_velocity.min_y="-30" 
+    randomize_velocity.max_y="30"
+    randomize_velocity.min_x="-30" 	
+    randomize_velocity.max_x="30"
+    randomize_position.min_y="-2" 
+    randomize_position.max_y="2"
+    randomize_position.min_x="-2"  
+    randomize_position.max_x="2"
+    randomize_animation_speed_coeff.min="0.667"  
+    randomize_animation_speed_coeff.max="1.0" >
+  </SpriteParticleEmitterComponent>
 	
 	<LightComponent 
 		_enabled="1" 
@@ -50,8 +48,7 @@
 		g="235"
 		b="0"
 		radius="52" 
-		fade_out_time="2"
-		>
+		fade_out_time="2">
 	</LightComponent>
   
 </Entity>

--- a/files/data/scripts/items/drop_health_container.lua
+++ b/files/data/scripts/items/drop_health_container.lua
@@ -1,14 +1,12 @@
 dofile_once("data/scripts/lib/utilities.lua")
-dofile( "mods/health_container/config.lua" )
 
 function do_money_drop( amount_multiplier )	
 	local entity = GetUpdatedEntityID()
 	local x, y = EntityGetTransform( entity )
-	local rand = math.random( 0, DropChance )
 	
 	if ( GameGetIsTrailerModeEnabled() ) then return end
 
-	if( rand == 0 ) then 
+	if( math.random() < ModSettingGet("health_container.drop_chance") ) then 
 		EntityLoad( "mods/health_container/files/data/entities/items/pickup/health_container.xml", x, y-8 )
 	end
 end

--- a/files/data/scripts/items/health_container_pickup.lua
+++ b/files/data/scripts/items/health_container_pickup.lua
@@ -1,28 +1,47 @@
 dofile_once( "data/scripts/game_helpers.lua" )
 dofile_once("data/scripts/lib/utilities.lua")
-dofile( "mods/health_container/config.lua" )
 
 function item_pickup( entity_item, entity_who_picked, item_name )
+  local function TruncateHpValue( value )
+    -- this function reduces inaccuracy building up over time due to how HP is handled and 
+    -- how this version of lua seems to handle floating point values.
+    -- This function truncates values less than 1 HP (<0.04)
+    local shifted = value * 100
+    local truncated = shifted - (shifted % 4)
+    return truncated / 100
+  end
+
 	local pos_x, pos_y = EntityGetTransform( entity_item )
 	
 	local damagemodels = EntityGetComponent( entity_who_picked, "DamageModelComponent" )
 	
 	if( damagemodels ~= nil ) then
 		for i,v in ipairs(damagemodels) do
-			currenthp = tonumber( ComponentGetValue( v, "hp" ) )
-      current_max_hp = tonumber( ComponentGetValue( v, "max_hp") )
-      increase_amt = 0
-      if( HealMode ~= "PERCENT" ) then
-        increase_amt = current_max_hp * HealPercent
+			local current_hp = tonumber( ComponentGetValue( v, "hp" ) )
+      local current_max_hp = tonumber( ComponentGetValue( v, "max_hp") )
+      local heal_amt = 0
+      local mode = ModSettingGet("health_container.heal_mode")
+      if( tostring(mode) == "percent" ) then
+        heal_amt = current_max_hp * ( ModSettingGet("health_container.heal_percent"))
       else
-        increase_amt = HealAmount * 0.04 -- Health values are scaled up by 25 in the UI apparently. So using this multiplier will allow the correct hp to be set
+        heal_amt = ModSettingGet("health_container.heal_amount") -- Health values are scaled up by 25 in the UI apparently.
       end
-			local targethp = currenthp + Math.floor(increase_amt)
-			local target_max_hp = current_max_hp + (MaxHealthIncrease * 0.04)
-			
+      heal_amt = math.max(heal_amt, 0.04) -- set heal_amt to be at least 1 HP
+      local target_hp = TruncateHpValue(current_hp + heal_amt)
+      
+      -- handle expansion of max HP:
+      local max_incr_amt = ModSettingGet("health_container.max_health_increase")
+      if (max_incr_amt > 0) then
+        max_incr_amt = math.max(0.04, max_incr_amt) -- set increase amt to at least 1 HP
+      end
+
+			local target_max_hp = TruncateHpValue(current_max_hp + max_incr_amt)
+
+      -- Save values
 			ComponentSetValue( v, "max_hp", target_max_hp)
-			if( targethp > target_max_hp ) then targethp = target_max_hp end
-			ComponentSetValue( v, "hp", targethp)
+			if( target_hp > target_max_hp ) then target_hp = target_max_hp end
+      ComponentSetValue( v, "hp", target_hp)
+      GamePrint("Picked up Health (" .. (TruncateHpValue(heal_amt) * 25) .. ")")
 			break
 		end
 	end

--- a/files/data/scripts/items/health_container_pickup.lua
+++ b/files/data/scripts/items/health_container_pickup.lua
@@ -10,9 +10,14 @@ function item_pickup( entity_item, entity_who_picked, item_name )
 	if( damagemodels ~= nil ) then
 		for i,v in ipairs(damagemodels) do
 			currenthp = tonumber( ComponentGetValue( v, "hp" ) )
-			current_max_hp = tonumber( ComponentGetValue( v, "max_hp") )
-			
-			local targethp = currenthp + (HealAmount * 0.04) -- Health values are scaled up by 25 in the UI apparently. So using this multiplier will allow the correct hp to be set
+      current_max_hp = tonumber( ComponentGetValue( v, "max_hp") )
+      increase_amt = 0
+      if( HealMode ~= "PERCENT" ) then
+        increase_amt = current_max_hp * HealPercent
+      else
+        increase_amt = HealAmount * 0.04 -- Health values are scaled up by 25 in the UI apparently. So using this multiplier will allow the correct hp to be set
+      end
+			local targethp = currenthp + Math.floor(increase_amt)
 			local target_max_hp = current_max_hp + (MaxHealthIncrease * 0.04)
 			
 			ComponentSetValue( v, "max_hp", target_max_hp)

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,97 @@
+dofile("data/scripts/lib/mod_settings.lua")
+
+-- Use ModSettingGet() in the game to query settings.
+local mod_id = "health_container"
+mod_settings_version = 1
+mod_settings = 
+{
+  {
+    category_id = "health_container_settings",
+    ui_name = "Health Container Settings",
+    ui_description = "Settings for the health container drops",
+    settings = 
+    {
+      {
+        id = "drop_chance",
+        ui_name = "Drop Chance",
+        ui_description = "Chance that a health container drops upon killing an enemy",
+        value_default = 0.5,
+        value_min = 0,
+        value_max = 1,
+        value_display_multiplier = 100,
+        value_display_formatting = " $0 %",
+        scope = MOD_SETTING_SCOPE_RUNTIME,
+      },
+      {
+        id = "max_health_increase",
+        ui_name = "Max Health Increase",
+        ui_description = "Amount to increase the max player health by. Takes effect on new game.",
+        value_default = 0,
+        value_min = 0,
+        value_max = 4,
+        value_display_multiplier = 25,
+        value_display_formatting = " $0 HP",
+        scope = MOD_SETTING_SCOPE_NEW_GAME,
+      },
+      {
+        id = "heal_mode",
+        ui_name = "Health Container Healing Mode",
+        ui_description = "Set whether health containers heal a fixed amount or a percent of max health",
+        value_default = "percent",
+        values = { {"percent", "Percent"}, {"fixed", "Fixed"} },
+        scope = MOD_SETTING_SCOPE_RUNTIME,
+      },
+      {
+        id = "heal_amount",
+        ui_name = "Healing Amount (Fixed)",
+        ui_description = "Fixed amount of HP to heal each pickup",
+        value_default = 0.4,
+        value_min = 0,
+        value_max = 4,
+        value_display_multiplier = 25,
+        value_display_formatting = " $0 HP",
+        scope = MOD_SETTING_SCOPE_RUNTIME,
+      },
+      {
+        id = "heal_percent",
+        ui_name = "Healing Amount (Percentage)",
+        ui_description = "Percentage of Max HP to heal on each pickup",
+        value_default = 0.10,
+        value_min = 0,
+        value_max = 1,
+        value_display_multiplier = 100,
+        value_display_formatting = " $0 %",
+        scope = MOD_SETTING_SCOPE_RUNTIME,
+      }
+    }
+  }
+}
+
+-- This function is called to ensure the correct setting values are visible to the game via ModSettingGet(). your mod's settings don't work if you don't have a function like this defined in settings.lua.
+-- This function is called:
+--		- when entering the mod settings menu (init_scope will be MOD_SETTINGS_SCOPE_ONLY_SET_DEFAULT)
+-- 		- before mod initialization when starting a new game (init_scope will be MOD_SETTING_SCOPE_NEW_GAME)
+--		- when entering the game after a restart (init_scope will be MOD_SETTING_SCOPE_RESTART)
+--		- at the end of an update when mod settings have been changed via ModSettingsSetNextValue() and the game is unpaused (init_scope will be MOD_SETTINGS_SCOPE_RUNTIME)
+function ModSettingsUpdate( init_scope )
+	local old_version = mod_settings_get_version( mod_id ) -- This can be used to migrate some settings between mod versions.
+	mod_settings_update( mod_id, mod_settings, init_scope )
+end
+
+-- This function should return the number of visible setting UI elements.
+-- Your mod's settings wont be visible in the mod settings menu if this function isn't defined correctly.
+-- If your mod changes the displayed settings dynamically, you might need to implement custom logic.
+-- The value will be used to determine whether or not to display various UI elements that link to mod settings.
+-- At the moment it is fine to simply return 0 or 1 in a custom implementation, but we don't guarantee that will be the case in the future.
+-- This function is called every frame when in the settings menu.
+function ModSettingsGuiCount()
+	-- if (not DebugGetIsDevBuild()) then --if these lines are enabled, the menu only works in noita_dev.exe.
+	-- 	return 0
+	-- end
+
+	return mod_settings_gui_count( mod_id, mod_settings )
+end
+
+function ModSettingsGui( gui, in_main_menu )
+  mod_settings_gui( mod_id, mod_settings, gui, in_main_menu )
+end


### PR DESCRIPTION
I added some features requested by reviews on the Steam Workshop - many people (including me) seemed to want the option for health containers to heal a percentage of the player's current max HP. This change implements that feature.

Also, as a quality of life improvement for the mod overall, I implemented a settings menu for the mod, so that parameters can be changed from within the game via the mod menu, rather than via a config file. I set most settings, such as the fixed amount of health to heal, the percentage of health to heal, and the drop percent chance to take effect immediately if changed in the menu, but the amount of health to increase per pickup to only change on a new game.

Finally, some things weren't working for me so I may have renamed some things that could cause problems. That being said, it all seems to be working without bugs for me with the latest version of the game from Steam.